### PR TITLE
Adjustments: Reset triggers, routes new priority and more

### DIFF
--- a/replies/index.js
+++ b/replies/index.js
@@ -78,7 +78,7 @@ const defaultReplies = {
             body: `${options ? `:\n\n${options}` : '.'}`,
             footer: `Para reservar acesse ${url}`
         }),
-        detail: () => 'Checar'
+        detail: () => 'Escolher'
     },
     // ## Unexpected answer
     unknown: () => (DEBUG_TO_LOGFILE

--- a/src/reducer.js
+++ b/src/reducer.js
@@ -4,7 +4,10 @@ import {
     UPDATE_CHAT_SESSION
 } from './actionTypes';
 
-const expireSessionTime = 15 * 60 * 1000; // 15 minutes
+import { WitDriver } from 'calamars';
+const { getEntityValue } = WitDriver;
+
+const expireSessionTime = 3 * 60 * 1000; // 3 minutes
 
 const updateArrayItem = (arr, i, newItem) => {
     const shouldReplaceItem = (i > -1 && newItem !== null);

--- a/src/reducer.js
+++ b/src/reducer.js
@@ -4,9 +4,6 @@ import {
     UPDATE_CHAT_SESSION
 } from './actionTypes';
 
-import { WitDriver } from 'calamars';
-const { getEntityValue } = WitDriver;
-
 const expireSessionTime = 3 * 60 * 1000; // 3 minutes
 
 const updateArrayItem = (arr, i, newItem) => {

--- a/src/router.js
+++ b/src/router.js
@@ -7,8 +7,8 @@ import insultRoutes from './routes/insult';
 
 const routes = [
     ...faqRoutes,
-    ...tripRoutes,
     ...commandRoutes,
+    ...tripRoutes,
     ...interactionRoutes,
     ...insultRoutes
 ];

--- a/src/routes/interactions.js
+++ b/src/routes/interactions.js
@@ -1,9 +1,14 @@
 import { replies } from '../../replies';
+import { updateChatSession } from '../actionCreators';
 import { WitDriver } from 'calamars';
+
 const { getEntityValue } = WitDriver;
 const routes = [[
     outcomes => getEntityValue(outcomes, 'interaction') === 'close',
-    replies.close
+    (outcomes, { store, chat, date }) => {
+        store.dispatch(updateChatSession({ date, chat: { ...chat, session: {} } }));
+        return replies.close();
+    }
 ], [
     outcomes => (
         getEntityValue(outcomes, 'interaction') === 'laugh' ||


### PR DESCRIPTION
Patch notes:

- Carousel's "Checar" button now is called "Escolher"
- Expiring session time changed from 15min to 3min
- New priority on routes: now command has higher priority than trips
- Reset triggers: interaction-close messages are wiping the context